### PR TITLE
Add ability to add docker and docker-compose to servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+## Galaxy Roles
+
+These roles are listed in the `requirements.yml` file and added to the
+workstation by issuing:
+
+```
+ansible-galaxy install --roles-path ./galaxy -r requirements.yml
+```
+
+The `ansible.cfg` file includes the directive to include the `./galaxy`
+directory when looking for roles.
+
+## Playbooks
+
+### provision_docker.yml
+
+Adds the docker installation repository and then installs `docker` and
+`docker-compose`.
+
+## Warnings & Troubleshooting
+
+The `python` library `urllib3` may need to be updated on each system in order to
+install docker.
+
+```
+pip install urllib3 --upgrade
+```

--- a/inventories/production/hosts
+++ b/inventories/production/hosts
@@ -7,3 +7,7 @@ lw-mc-03.metacpan.org
 bm-mc-01.metacpan.org
 bm-mc-02.metacpan.org
 bm-mc-04.metacpan.org
+
+[container_hosts]
+lw-mc-01.metacpan.org
+lw-mc-02.metacpan.org

--- a/inventories/production/hosts
+++ b/inventories/production/hosts
@@ -1,0 +1,9 @@
+[liquidweb]
+lw-mc-01.metacpan.org
+lw-mc-02.metacpan.org
+lw-mc-03.metacpan.org
+
+[bytemark]
+bm-mc-01.metacpan.org
+bm-mc-02.metacpan.org
+bm-mc-04.metacpan.org

--- a/inventories/staging/hosts
+++ b/inventories/staging/hosts
@@ -1,0 +1,3 @@
+
+[bytemark]
+bm-mc-03.metacpan.org

--- a/playbooks/provision_docker.yml
+++ b/playbooks/provision_docker.yml
@@ -1,0 +1,13 @@
+---
+
+- hosts: container_hosts
+  vars:
+    docker_edition: 'ce'
+    docker_package: "docker-{{ docker_edition }}"
+    docker_package_state: present
+    docker_install_compose: true
+    docker_compose_version: "1.24.0"
+    docker_compose_path: /usr/local/bin/docker-compose
+  roles:
+    - role: geerlingguy.docker
+      become: yes

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,7 @@
+# Install Ansible Roles
+# ---------------------
+# `ansible-galaxy install --roles-path ./galaxy -r requirements.yml` is executed
+# using this file. Follow the instructions at http://docs.ansible.com/ansible/galaxy.html
+# to include any roles you want installed prior to running main.yml.
+
+- src: geerlingguy.docker


### PR DESCRIPTION
This is just the beginning with a third party role that installs docker and docker-compose onto the hosts in the `[container_hosts]` group.