### PR TITLE
Add starter ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,4 @@
+# Set any ansible.cfg overrides in this file.
+# See: https://docs.ansible.com/ansible/intro_configuration.html#explanation-of-values-by-section
+[defaults]
+roles_path = ./roles:./galaxy


### PR DESCRIPTION
This file was referenced earlier but not included. It adds the
configuration required to allow Ansible to use roles that are in the
galaxy directory.