### PR TITLE
Add become_user for docker commands

### DIFF
--- a/roles/deploy_site/tasks/compose_pull.yml
+++ b/roles/deploy_site/tasks/compose_pull.yml
@@ -4,3 +4,5 @@
   shell: "/usr/local/bin/docker-compose pull {{ site }}"
   args:
     chdir: "{{ docker_mgmt['directory'] }}"
+  become: yes
+  become_user: "{{ metacpan_user | default(docker_mgmt.git.user) }}"

--- a/roles/deploy_site/tasks/compose_up.yml
+++ b/roles/deploy_site/tasks/compose_up.yml
@@ -15,3 +15,5 @@
     -d {{ site | mandatory }}
   args:
     chdir: "{{ docker_mgmt['directory'] | mandatory }}"
+  become: yes
+  become_user: "{{ metacpan_user | default(docker_mgmt.git.user) }}"


### PR DESCRIPTION
These commands need to be executed by the user that is running the
containers (metacpan), and thus the need for `become_user` on each.