### PR TITLE
Add hourly cron entry to run data population

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,5 +60,6 @@ script:
     | grep -q 'changed=2.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+  - grep github-meets-cpan-cron /etc/cron.d/github-meets-cpan
 
   - cd /home/metacpan/docker-production && /usr/local/bin/docker-compose ps

--- a/playbooks/deploy_github-meets-cpan.yml
+++ b/playbooks/deploy_github-meets-cpan.yml
@@ -9,3 +9,13 @@
     - ../vars/settings.yml
   roles:
     - deploy_site
+
+- hosts: github-meets-cpan
+  tasks:
+    - name: Create cron entries for github-meets-cpan
+      cron:
+        name: update data
+        cron_file: github-meets-cpan
+        user: "{{ metacpan_user | default(docker_mgmt.git.user) }}"
+        special_time: hourly
+        job: "cd {{ docker_mgmt['directory'] }} && /usr/local/bin/docker-compose start github-meets-cpan-cron"

--- a/tests/deploy_github-meets-cpan.yml
+++ b/tests/deploy_github-meets-cpan.yml
@@ -6,3 +6,14 @@
     site: github-meets-cpan
   roles:
     - deploy_site
+
+- hosts: github-meets-cpan
+  tasks:
+    - name: Create cron entries for github-meets-cpan
+      cron:
+        name: update data
+        cron_file: github-meets-cpan
+        user: "{{ metacpan_user | default(docker_mgmt.git.user) }}"
+        special_time: hourly
+        job: "cd {{ docker_mgmt['directory'] }} && /usr/local/bin/docker-compose start github-meets-cpan-cron"
+      become: yes


### PR DESCRIPTION
The github-meets-cpan-cron container starts the data population script
automatically on start up. Create a cron entry that runs every hour (and
test that Ansible is creating it in Travis).