### PR TITLE
Fixes from latest deployment run

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,6 @@
 # See: https://docs.ansible.com/ansible/intro_configuration.html#explanation-of-values-by-section
 [defaults]
 roles_path = ./roles:./galaxy
+
+[ssh_connection]
+pipelining = true

--- a/playbooks/deploy_github-meets-cpan.yml
+++ b/playbooks/deploy_github-meets-cpan.yml
@@ -19,3 +19,4 @@
         user: "{{ metacpan_user | default(docker_mgmt.git.user) }}"
         special_time: hourly
         job: "cd {{ docker_mgmt['directory'] }} && /usr/local/bin/docker-compose start github-meets-cpan-cron"
+      become: yes


### PR DESCRIPTION
Added ssh pipelining to make the deployment run a bit faster. Not that a lot is happening right now, but it's good to get this setting into place while it's on the mind.

Missed adding the `become_user` to the production playbook. This caused the deployment to fail because my user can't write to `/etc/cron.d`.