### PR TITLE
Add output redirection for cron entry

### DIFF
--- a/playbooks/deploy_github-meets-cpan.yml
+++ b/playbooks/deploy_github-meets-cpan.yml
@@ -18,5 +18,5 @@
         cron_file: github-meets-cpan
         user: "{{ metacpan_user | default(docker_mgmt.git.user) }}"
         special_time: hourly
-        job: "cd {{ docker_mgmt['directory'] }} && /usr/local/bin/docker-compose start github-meets-cpan-cron"
+        job: "cd {{ docker_mgmt['directory'] }} && /usr/local/bin/docker-compose start github-meets-cpan-cron > /dev/null 2>&1"
       become: yes


### PR DESCRIPTION
Stop all the emails for docker-compose starting up for the cron job to
populate github-meets-cpan.

Unfortunately, docker-compose has an outstanding pull request
(https://github.com/docker/compose/issues/6026) to fix the functionality
of `--log-level` with the `up` and `run` command so that they can run
silently but still print out errors from the containers. The work around
until such a time is to direct output to `/dev/null` for both STDOUT and
STDERR.