### PR TITLE
Add deploy_sites playbook

### DIFF
--- a/playbooks/deploy_sites.yml
+++ b/playbooks/deploy_sites.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Docker Management
+  import_playbook: deploy_docker_mgmt.yml
+
+- name: Deploy GitHub Meets CPAN
+  import_playbook: deploy_github-meets-cpan.yml
+
+- name: Deploy grep MetaCPAN
+  import_playbook: deploy_grep_metacpan.yml
+
+- name: Deploy Hound MetaCPAN
+  import_playbook: deploy_hound_metacpan.yml
+
+- name: Deploy Web MetaCPAN
+  import_playbook: deploy_web_metacpan.yml


### PR DESCRIPTION
This playbook consolidates the docker_mgmt and site playbooks into one
playbook that can be deployed to a server or group of servers in one
pass, only deploying what is configured.